### PR TITLE
fix: reinforce bot identity in group chat system prompt

### DIFF
--- a/specs/agent/uc-06-system-prompt.md
+++ b/specs/agent/uc-06-system-prompt.md
@@ -31,7 +31,7 @@ The system prompt is assembled from 5 orthogonal layers joined by `\n\n---\n\n`.
 
 After the 5 layers, optional appendices:
 - **Session context**: Channel and Chat ID
-- **Group chat context**: Group name, user name, other bot names, round/MAX_ROUNDS pacing hints, conversational style rules (short, natural, phone-texting style)
+- **Group chat context**: Current bot name ("You are {botName} in a group chat"), group name, user name, other bot names, message format description (user messages as `[Name]:`, other bots as `<group_reply>` tags), round/MAX_ROUNDS pacing hints, conversational style rules (short, natural, phone-texting style)
 
 ## Example
 
@@ -45,7 +45,7 @@ buildSystemPrompt() for bot "Alice" in group chat round 3
 → Layer 5: "# Skills\n\n<skills>..."
 → Join with "\n\n---\n\n"
 → Append: "## Current Session\nChannel: telegram\nChat ID: 12345"
-→ Append: "## Group Chat [Round 3/8]\nYou are in a group chat..."
+→ Append: "## Group Chat [Round 3/8]\nYou are Alice in a group chat..."
 ```
 
 ## Token-Aware History Trimming

--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -106,6 +106,11 @@ function buildGroupSystemPrompt(
   groupContext: GroupContext,
   currentBotId: string,
 ): string {
+  const currentBot = groupContext.members.find(m => m.botId === currentBotId);
+  if (!currentBot) {
+    console.warn(`[buildGroupSystemPrompt] currentBotId "${currentBotId}" not found in members list`);
+  }
+  const currentBotName = currentBot?.botName ?? "unknown";
   const others = groupContext.members
     .filter(m => m.botId !== currentBotId)
     .map(m => `- ${m.botName}`)
@@ -126,13 +131,13 @@ function buildGroupSystemPrompt(
   }
 
   return `\n\n## Group Chat [Round ${groupContext.round}/${MAX_ROUNDS}]
-You are in a group chat "${groupContext.groupName}".
+You are ${currentBotName} in a group chat "${groupContext.groupName}".
 
 User: ${groupContext.userName}
 Other bots:
 ${others}${noteLine}
 
-Messages from the user and other bots are prefixed with "[Name]: ". Your own replies have no prefix.
+User messages are shown as "[Name]: message". Other bots' messages are wrapped in <group_reply from="Name"> tags. Your own previous replies have no prefix.
 
 You are texting on a phone in a group chat. Write like people actually text:
 - Keep it short and natural — a few words to a couple sentences is typical. Go longer only when sharing genuinely new information.


### PR DESCRIPTION
## Summary
- Group chat system prompt now explicitly states the current bot's name ("You are {botName} in a group chat") to prevent identity confusion in long conversations
- Fixed message format description to accurately reflect actual history formatting (user messages as `[Name]:`, other bots as `<group_reply>` tags)
- Added defensive `console.warn` when current bot is not found in group members list

## Root Cause
The group chat section of the system prompt did not identify which bot the LLM was. Identity was only established in Layer 1 at the top, which could be thousands of tokens away. In complex group conversations where the bot's name was frequently mentioned by others, the LLM lost track of its identity and generated responses as another participant.

## Test plan
- [x] All 1502 existing tests pass
- [ ] Verify in production group chat that bot maintains correct identity

Closes #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)