### PR TITLE
fix: merge consecutive assistant messages for Gemini compatibility

### DIFF
--- a/specs/agent/uc-07-agent-loop.md
+++ b/specs/agent/uc-07-agent-loop.md
@@ -7,7 +7,7 @@ Called by `processChat()` (for both `/chat` and `/group-chat`) and `executeCronJ
 ## Expected Behavior
 
 1. **Setup**: Wrap all tools with error handling (`wrapToolsWithErrorHandling`), apply Anthropic cache control to system prompt (`buildCachedSystemPrompt`), merge system messages + conversation history + current user turn
-2. **Consecutive user message merging**: Before sending to the LLM, `mergeConsecutiveUserMessages()` combines adjacent user-role messages into one. Prevents provider rejections (Anthropic/Gemini reject consecutive same-role messages) and improves LLM comprehension
+2. **Consecutive message merging**: Before sending to the LLM, `mergeConsecutiveMessages()` combines adjacent same-role messages. Prevents provider rejections (Gemini requires strict user/model alternation) and improves LLM comprehension. User messages are merged unconditionally; assistant messages are merged only when both are text-only (messages with tool-call parts are never merged, to preserve tool result pairing)
 3. **Loop iteration**: Up to `maxIterations` (from `botConfig.maxIterations`):
    a. Call `generateText()` with `stopWhen: stepCountIs(1)` — one LLM step per iteration
    b. Per-step timeout: 90 seconds (`STEP_TIMEOUT_MS`), combined with the parent abort signal via `AbortSignal.any()`
@@ -87,7 +87,7 @@ User asks: "Create a Python script that says hello"
 
 - Loop: `runAgentLoop()` in `loop.ts`
 - Error wrapping: `wrapToolsWithErrorHandling()` in `loop.ts`
-- Message merging: `mergeConsecutiveUserMessages()` in `loop.ts`
+- Message merging: `mergeConsecutiveMessages()` in `loop.ts`
 - Message conversion: `convertToStoredMessages()` in `loop.ts`
 - Tool hints: `formatToolHint()` in `loop.ts`
 - Cache control: `buildCachedSystemPrompt()` in `providers/cache.ts`
@@ -102,4 +102,5 @@ User asks: "Create a Python script that says hello"
 - **appendUserTurn=false**: When `coordinatorOwned=true` in group chat, the user message is already in D1 history. The loop skips appending it as the current turn to avoid duplication
 - **Skill tracking**: Tool calls are grouped by the active skill (set by `load_skill` calls). Tool calls before any `load_skill` are grouped under the empty string skill
 - **Max iterations reached**: Returns accumulated text or a fallback message. Does not throw — the conversation can continue normally
-- **Consecutive user messages in history**: Can occur from multi-turn group chat where the bot was silent. `mergeConsecutiveUserMessages()` joins them with `\n\n` for text-only or concatenates arrays for mixed content (text + images)
+- **Consecutive user messages in history**: Can occur from multi-turn group chat where the bot was silent. `mergeConsecutiveMessages()` joins them with `\n\n` for text-only or concatenates arrays for mixed content (text + images)
+- **Consecutive assistant messages in history**: Can occur in group chat when the same bot sends multiple messages without interleaving user/other-bot messages (e.g., cron messages). `mergeConsecutiveMessages()` merges text-only assistant messages with `\n\n`. Assistant messages with tool-call parts are never merged (tool-calls need their own turn for proper tool result pairing)

--- a/src/agent/loop.test.ts
+++ b/src/agent/loop.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { convertToStoredMessages, formatToolHint, wrapToolsWithErrorHandling, runAgentLoop, mergeConsecutiveUserMessages, TOOL_RESULT_MAX_LENGTH } from "./loop";
+import { convertToStoredMessages, formatToolHint, wrapToolsWithErrorHandling, runAgentLoop, mergeConsecutiveUserMessages, mergeConsecutiveMessages, TOOL_RESULT_MAX_LENGTH } from "./loop";
 import type { ModelMessage, ToolSet } from "ai";
 import { tool } from "ai";
 import { z } from "zod";
@@ -601,7 +601,7 @@ describe("mergeConsecutiveUserMessages", () => {
     expect(result[0].content).toBe("solo");
   });
 
-  it("does not merge system or assistant messages", () => {
+  it("does not merge system messages", () => {
     const messages: ModelMessage[] = [
       { role: "system", content: "sys1" },
       { role: "system", content: "sys2" },
@@ -659,6 +659,105 @@ describe("mergeConsecutiveUserMessages", () => {
     const result = mergeConsecutiveUserMessages(messages);
     expect(result).toHaveLength(1);
     expect(result[0].content).toEqual([{ type: "text", text: "text message\n\narray message" }]);
+  });
+});
+
+describe("mergeConsecutiveMessages — assistant merging", () => {
+  it("merges two consecutive text-only assistant messages", () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello" },
+      { role: "assistant", content: "how are you?" },
+    ];
+    const result = mergeConsecutiveMessages(messages);
+    expect(result).toHaveLength(2);
+    expect(result[1].role).toBe("assistant");
+    expect(result[1].content).toEqual([{ type: "text", text: "hello\n\nhow are you?" }]);
+  });
+
+  it("merges three consecutive text-only assistant messages", () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "one" },
+      { role: "assistant", content: "two" },
+      { role: "assistant", content: "three" },
+    ];
+    const result = mergeConsecutiveMessages(messages);
+    expect(result).toHaveLength(2);
+    expect(result[1].content).toEqual([{ type: "text", text: "one\n\ntwo\n\nthree" }]);
+  });
+
+  it("does not merge assistant message with tool-call parts into previous", () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "let me check" },
+      { role: "assistant", content: [{ type: "tool-call", toolCallId: "1", toolName: "exec", args: {} }] as any },
+    ];
+    const result = mergeConsecutiveMessages(messages);
+    expect(result).toHaveLength(3);
+    expect(result[1].content).toBe("let me check");
+    expect(result[2].content).toEqual([{ type: "tool-call", toolCallId: "1", toolName: "exec", args: {} }]);
+  });
+
+  it("does not merge text into previous assistant message with tool-call parts", () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "hi" },
+      { role: "assistant", content: [{ type: "tool-call", toolCallId: "1", toolName: "exec", args: {} }] as any },
+      { role: "assistant", content: "done" },
+    ];
+    const result = mergeConsecutiveMessages(messages);
+    expect(result).toHaveLength(3);
+  });
+
+  it("does not merge across tool result messages", () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "hi" },
+      { role: "assistant", content: [{ type: "tool-call", toolCallId: "1", toolName: "exec", args: {} }] as any },
+      { role: "tool", content: [{ type: "tool-result", toolCallId: "1", result: "ok" }] as any },
+      { role: "assistant", content: "first reply" },
+      { role: "assistant", content: "second reply" },
+    ];
+    const result = mergeConsecutiveMessages(messages);
+    expect(result).toHaveLength(4);
+    expect(result[3].content).toEqual([{ type: "text", text: "first reply\n\nsecond reply" }]);
+  });
+
+  it("still merges consecutive user messages", () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "hello" },
+      { role: "user", content: "world" },
+      { role: "assistant", content: "hi" },
+    ];
+    const result = mergeConsecutiveMessages(messages);
+    expect(result).toHaveLength(2);
+    expect(result[0].content).toEqual([{ type: "text", text: "hello\n\nworld" }]);
+  });
+
+  it("handles group chat pattern: cron messages creating consecutive assistants", () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "some message" },
+      { role: "assistant", content: "selfie reply with image" },
+      { role: "assistant", content: "cron daily post" },
+      { role: "user", content: "<group_reply from=\"小晚\">nice</group_reply>" },
+      { role: "assistant", content: "thanks!" },
+    ];
+    const result = mergeConsecutiveMessages(messages);
+    expect(result).toHaveLength(4);
+    expect(result[1].content).toEqual([{ type: "text", text: "selfie reply with image\n\ncron daily post" }]);
+    expect(result[2].content).toBe("<group_reply from=\"小晚\">nice</group_reply>");
+    expect(result[3].content).toBe("thanks!");
+  });
+
+  it("skips empty assistant messages during merge", () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello" },
+      { role: "assistant", content: "" },
+      { role: "assistant", content: "world" },
+    ];
+    const result = mergeConsecutiveMessages(messages);
+    expect(result).toHaveLength(2);
+    expect(result[1].content).toEqual([{ type: "text", text: "hello\n\nworld" }]);
   });
 });
 

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -256,33 +256,41 @@ function contentToArray(content: unknown): Array<Record<string, unknown>> {
 }
 
 /**
- * Merge consecutive user messages into a single message to improve LLM input quality.
- * Some providers (Anthropic, Gemini) reject consecutive same-role messages;
- * even for tolerant providers, a single coherent message is easier to understand.
- *
- * Text parts from consecutive messages are joined with "\n\n".
- * Non-text parts (images) are preserved in order.
+ * Check whether a content array contains any tool-call parts.
  */
-export function mergeConsecutiveUserMessages(messages: ModelMessage[]): ModelMessage[] {
+function hasToolCallParts(parts: Array<Record<string, unknown>>): boolean {
+  return parts.some((p) => p.type === "tool-call");
+}
+
+/**
+ * Merge consecutive same-role messages to ensure strict role alternation.
+ * Gemini requires strict user/model alternation and rejects consecutive same-role messages.
+ * Other providers (Claude, GPT) tolerate them but benefit from cleaner input.
+ *
+ * User messages: text parts joined with "\n\n", non-text parts (images) preserved in order.
+ * Assistant messages: text-only messages merged with "\n\n". Messages with tool-call parts
+ * are NOT merged into (tool-calls should stay as distinct turns for proper tool result pairing).
+ * An assistant message with tool-calls that has no preceding tool result is malformed — left as-is.
+ */
+export function mergeConsecutiveMessages(messages: ModelMessage[]): ModelMessage[] {
   if (messages.length <= 1) return messages;
 
   const result: ModelMessage[] = [];
 
   for (const msg of messages) {
     const prev = result[result.length - 1];
+
+    // --- Merge consecutive user messages ---
     if (prev && prev.role === "user" && msg.role === "user") {
-      // Merge into previous user message (immutable — replace last element)
       const prevParts = contentToArray(prev.content);
       const currParts = contentToArray(msg.content);
 
-      // Skip empty messages to avoid producing invalid empty content
       if (currParts.length === 0) continue;
       if (prevParts.length === 0) {
         result[result.length - 1] = { ...msg };
         continue;
       }
 
-      // If both are pure text, join with \n\n as a single text part
       const prevAllText = prevParts.every((p) => p.type === "text");
       const currAllText = currParts.every((p) => p.type === "text");
 
@@ -292,17 +300,60 @@ export function mergeConsecutiveUserMessages(messages: ModelMessage[]): ModelMes
         const currText = currParts.map((p) => p.text).join("");
         mergedContent = [{ type: "text", text: `${prevText}\n\n${currText}` }];
       } else {
-        // Mixed content (text + images): concatenate arrays
         mergedContent = [...prevParts, ...currParts];
       }
       result[result.length - 1] = { ...prev, content: mergedContent as any };
-    } else {
-      result.push({ ...msg });
+      continue;
     }
+
+    // --- Merge consecutive assistant messages (text-only) ---
+    if (prev && prev.role === "assistant" && msg.role === "assistant") {
+      const prevParts = contentToArray(prev.content);
+      const currParts = contentToArray(msg.content);
+
+      // Never merge INTO a message that has tool-call parts (it needs its own tool result)
+      if (hasToolCallParts(prevParts)) {
+        result.push({ ...msg });
+        continue;
+      }
+      // Never merge a message that has tool-call parts into a text message
+      // (tool-call after plain assistant text is malformed — leave as-is for debugging)
+      if (hasToolCallParts(currParts)) {
+        result.push({ ...msg });
+        continue;
+      }
+
+      // Both are text-only assistant messages — safe to merge
+      if (currParts.length === 0) continue;
+      if (prevParts.length === 0) {
+        result[result.length - 1] = { ...msg };
+        continue;
+      }
+
+      const prevAllText = prevParts.every((p) => p.type === "text");
+      const currAllText = currParts.every((p) => p.type === "text");
+
+      let mergedContent: unknown;
+      if (prevAllText && currAllText) {
+        const prevText = prevParts.map((p) => p.text).join("");
+        const currText = currParts.map((p) => p.text).join("");
+        mergedContent = [{ type: "text", text: `${prevText}\n\n${currText}` }];
+      } else {
+        // Mixed content (text + non-text parts): concatenate arrays to preserve all parts
+        mergedContent = [...prevParts, ...currParts];
+      }
+      result[result.length - 1] = { ...prev, content: mergedContent as any };
+      continue;
+    }
+
+    result.push({ ...msg });
   }
 
   return result;
 }
+
+/** @deprecated Use mergeConsecutiveMessages instead */
+export const mergeConsecutiveUserMessages = mergeConsecutiveMessages;
 
 export async function runAgentLoop(params: {
   model: LanguageModel;
@@ -375,8 +426,9 @@ export async function runAgentLoop(params: {
     rawMessages.push({ role: "user", content: userContent as any });
   }
 
-  // Merge consecutive user messages before sending to LLM
-  const messages: ModelMessage[] = mergeConsecutiveUserMessages(rawMessages);
+  // Merge consecutive same-role messages before sending to LLM
+  // (Gemini requires strict user/model alternation)
+  const messages: ModelMessage[] = mergeConsecutiveMessages(rawMessages);
 
   let iterations = 0;
   let toolCallsTotal = 0;


### PR DESCRIPTION
## Summary

- Gemini requires strict user/model alternation but group chat can produce consecutive assistant messages from the same bot (e.g., cron messages with no user interaction between them), causing 400 errors
- Root cause: `mergeConsecutiveUserMessages` only handled user messages, not assistant messages
- Fix: extend into `mergeConsecutiveMessages` that also merges consecutive text-only assistant messages with `\n\n`; messages with tool-call parts are never merged to preserve tool result pairing
- Old function kept as deprecated alias for backward compatibility

## Test plan

- [x] New tests: consecutive assistant text merge, tool-call parts not merged, cross-tool-result not merged, group chat cron pattern, empty message handling
- [x] Existing user merge tests still pass via deprecated alias
- [x] All 1513 tests pass (67 test files)
- [ ] Verify cron-triggered group chat no longer causes Gemini 400 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)