### PR TITLE
feat: add search_bot_memory tool for admin bot

### DIFF
--- a/specs/tools/uc-03-memory-tools.md
+++ b/specs/tools/uc-03-memory-tools.md
@@ -59,5 +59,6 @@ LLM calls: memory_append({ file: "HISTORY.md", content: "2026-03-11: User asked 
 The admin bot has additional tools for managing other bots' memory:
 
 - **read_bot_memory**: Read another bot's MEMORY.md or HISTORY.md (with truncation)
+- **search_bot_memory**: Search another bot's MEMORY.md or HISTORY.md for entries containing a keyword. MEMORY.md uses case-insensitive line-by-line matching (same as `memory_grep`). HISTORY.md uses `searchHistoryEntries()` D1 LIKE query. Returns matching lines/entries or "No matches"
 - **edit_bot_memory**: Edit another bot's MEMORY.md only (find-and-replace). Does NOT accept HISTORY.md -- the `file` parameter was removed since HISTORY.md editing is never allowed. Blocked for admin bot targets
 - **correct_bot_history**: Append a `[CORRECTION]` entry to another bot's HISTORY.md. Used when a bot has incorrect information in its history that could pollute memory review. This preserves the append-only design -- existing entries are never modified, corrections are appended so the memory review process picks them up. For immediate fixes, the admin should also use `edit_bot_memory` to correct MEMORY.md directly

--- a/src/tools/admin.test.ts
+++ b/src/tools/admin.test.ts
@@ -45,10 +45,11 @@ vi.mock("../db/d1", () => ({
   upsertMemory: vi.fn(),
   getHistoryEntries: vi.fn(),
   insertHistoryEntry: vi.fn(),
+  searchHistoryEntries: vi.fn(),
 }));
 
 import * as configDb from "../db/config";
-import { getMemory, upsertMemory, getHistoryEntries, insertHistoryEntry } from "../db/d1";
+import { getMemory, upsertMemory, getHistoryEntries, insertHistoryEntry, searchHistoryEntries } from "../db/d1";
 import { listAllSkills } from "../skills/loader";
 
 // ---------------------------------------------------------------------------
@@ -1279,6 +1280,87 @@ describe("createAdminTools", () => {
         correction: "[CORRECTION] something",
       });
       expect(result).toContain("Cannot modify admin bot");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // search_bot_memory
+  // -------------------------------------------------------------------------
+
+  describe("search_bot_memory", () => {
+    it("searches MEMORY.md with case-insensitive line matching", async () => {
+      vi.mocked(configDb.getBot).mockResolvedValue(makeBot({ botId: "b1", name: "TestBot" }));
+      vi.mocked(getMemory).mockResolvedValue("# Profile\nFavorite color: blue\nLanguage: English\nFavorite food: pizza");
+      const result = await exec(tools, "search_bot_memory", {
+        botId: "b1",
+        file: "MEMORY.md",
+        query: "favorite",
+      });
+      expect(result).toContain("Favorite color: blue");
+      expect(result).toContain("Favorite food: pizza");
+      expect(result).not.toContain("Language");
+    });
+
+    it("searches HISTORY.md via D1 searchHistoryEntries", async () => {
+      vi.mocked(configDb.getBot).mockResolvedValue(makeBot({ botId: "b1", name: "TestBot" }));
+      vi.mocked(searchHistoryEntries).mockResolvedValue([
+        { id: 1, content: "2026-03-01: Talked about cats", created_at: "2026-03-01" },
+        { id: 2, content: "2026-03-10: User loves cats", created_at: "2026-03-10" },
+      ]);
+      const result = await exec(tools, "search_bot_memory", {
+        botId: "b1",
+        file: "HISTORY.md",
+        query: "cats",
+      });
+      expect(result).toContain("Talked about cats");
+      expect(result).toContain("User loves cats");
+      expect(searchHistoryEntries).toHaveBeenCalledWith(env.D1_DB, "b1", "cats");
+    });
+
+    it("returns no matches for MEMORY.md when query not found", async () => {
+      vi.mocked(configDb.getBot).mockResolvedValue(makeBot({ botId: "b1", name: "TestBot" }));
+      vi.mocked(getMemory).mockResolvedValue("# Profile\nFavorite color: blue");
+      const result = await exec(tools, "search_bot_memory", {
+        botId: "b1",
+        file: "MEMORY.md",
+        query: "pizza",
+      });
+      expect(result).toContain("No matches");
+      expect(result).toContain("TestBot");
+    });
+
+    it("returns no matches for empty MEMORY.md", async () => {
+      vi.mocked(configDb.getBot).mockResolvedValue(makeBot({ botId: "b1", name: "TestBot" }));
+      vi.mocked(getMemory).mockResolvedValue("");
+      const result = await exec(tools, "search_bot_memory", {
+        botId: "b1",
+        file: "MEMORY.md",
+        query: "anything",
+      });
+      expect(result).toContain("empty");
+      expect(result).toContain("TestBot");
+    });
+
+    it("returns no matches for HISTORY.md when query not found", async () => {
+      vi.mocked(configDb.getBot).mockResolvedValue(makeBot({ botId: "b1", name: "TestBot" }));
+      vi.mocked(searchHistoryEntries).mockResolvedValue([]);
+      const result = await exec(tools, "search_bot_memory", {
+        botId: "b1",
+        file: "HISTORY.md",
+        query: "nonexistent",
+      });
+      expect(result).toContain("No matches");
+      expect(result).toContain("TestBot");
+    });
+
+    it("returns error for non-existent bot", async () => {
+      vi.mocked(configDb.getBot).mockResolvedValue(null);
+      const result = await exec(tools, "search_bot_memory", {
+        botId: "missing",
+        file: "MEMORY.md",
+        query: "test",
+      });
+      expect(result).toContain("Bot not found");
     });
   });
 

--- a/src/tools/admin/observability.ts
+++ b/src/tools/admin/observability.ts
@@ -6,7 +6,7 @@ import { tool } from "ai";
 import type { ToolSet } from "ai";
 import { z } from "zod";
 import * as configDb from "../../db/config";
-import { getMemory, upsertMemory, getHistoryEntries, insertHistoryEntry } from "../../db/d1";
+import { getMemory, upsertMemory, getHistoryEntries, insertHistoryEntry, searchHistoryEntries } from "../../db/d1";
 import type { AdminToolDeps } from "./utils";
 
 export function createObservabilityTools(deps: AdminToolDeps): ToolSet {
@@ -170,6 +170,42 @@ export function createObservabilityTools(deps: AdminToolDeps): ToolSet {
           return `Appended correction to HISTORY.md for **${bot.name}** (\`${botId}\`).`;
         } catch (err) {
           return `Failed to append correction: ${err instanceof Error ? err.message : String(err)}`;
+        }
+      },
+    }),
+
+    search_bot_memory: tool({
+      description:
+        "Search another bot's memory file for entries containing a keyword. Returns matching lines (MEMORY.md) or entries (HISTORY.md). Useful for finding specific information without reading the entire file.",
+      inputSchema: z.object({
+        botId: z.string().describe("Target bot ID"),
+        file: z
+          .enum(["MEMORY.md", "HISTORY.md"])
+          .describe("Which memory file to search"),
+        query: z.string().min(1).describe("The search keyword or phrase"),
+      }),
+      execute: async ({ botId, file, query }) => {
+        try {
+          const bot = await configDb.getBot(db, ownerId, botId);
+          if (!bot) return `Bot not found: ${botId}`;
+
+          if (file === "HISTORY.md") {
+            const results = await searchHistoryEntries(db, botId, query);
+            if (results.length === 0) return `No matches for "${query}" in HISTORY.md of **${bot.name}**.`;
+            return results.map((e) => e.content).join("\n\n");
+          }
+
+          // MEMORY.md: case-insensitive line-by-line search
+          const content = await getMemory(db, botId);
+          if (!content) return `No matches (MEMORY.md is empty for **${bot.name}**).`;
+          const lines = content.split("\n");
+          const matches = lines.filter((line) =>
+            line.toLowerCase().includes(query.toLowerCase())
+          );
+          if (matches.length === 0) return `No matches for "${query}" in MEMORY.md of **${bot.name}**.`;
+          return matches.join("\n");
+        } catch (err) {
+          return `Failed to search bot memory: ${err instanceof Error ? err.message : String(err)}`;
         }
       },
     }),


### PR DESCRIPTION
## Summary

- Admin bot 新增 `search_bot_memory` 工具，可搜索其他 bot 的 MEMORY.md 和 HISTORY.md
- MEMORY.md 使用大小写不敏感的逐行匹配（与 `memory_grep` 一致）
- HISTORY.md 使用已有的 `searchHistoryEntries()` D1 LIKE 查询
- query 参数添加 `.min(1)` 校验，防止空查询
- 补充了 6 个测试用例，更新了 spec

Closes #12
Closes codance-ai/multibot-private#793

## Test plan

- [x] 所有 1519 个测试通过
- [x] 新增 6 个 search_bot_memory 测试覆盖：MEMORY.md 搜索、HISTORY.md 搜索、无匹配、空文件、bot 不存在

🤖 Generated with [Claude Code](https://claude.com/claude-code)