### PR TITLE
fix: skip memory review for admin bot to prevent cross-contamination

### DIFF
--- a/specs/agent/uc-05-memory-review.md
+++ b/specs/agent/uc-05-memory-review.md
@@ -46,6 +46,7 @@ Cron fires memory review for bot "Alice"
 
 ## Edge Cases
 
+- **Admin bot excluded**: Admin bots (`botType === "admin"`) are skipped in both the cron review loop and the eager review path after high-pressure consolidation. Their conversations consist of bot management operations (editing other bots' config/memory), which would pollute their own MEMORY.md with other bots' persona details
 - **No history entries**: Returns `false` immediately — nothing to review
 - **Empty current memory**: Works fine — LLM creates memory from scratch based on history entries
 - **LLM produces empty output**: Returns `false` — no memory update

--- a/src/agent/multibot.ts
+++ b/src/agent/multibot.ts
@@ -800,7 +800,7 @@ export class MultibotAgent extends Agent<Env> {
 
         // Eager memory review: when token pressure is high, fast-track key facts
         // into long-term memory instead of waiting for the next cron cycle.
-        if (tokenTriggered) {
+        if (tokenTriggered && botConfig.botType !== "admin") {
           try {
             const reviewed = await reviewMemory({
               model, db: this.db, botId: botConfig.botId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,6 +160,9 @@ export default {
       try {
         const botConfig = await configDb.getBot(db, owner_id, bot_id);
         if (!botConfig) continue;
+        // Admin bot manages other bots — its history entries contain other bots'
+        // persona details which would pollute its own MEMORY.md. Skip review.
+        if (botConfig.botType === "admin") continue;
 
         const userKeys = await configDb.getUserKeys(db, owner_id);
         if (!userKeys) continue;


### PR DESCRIPTION
## Summary

- Admin bot 的记忆出现串扰：MEMORY.md 中包含了小绵、小晚、Max 的完整人设详情
- 根因：用户通过 Admin 管理其他 bot，memory review 的 LLM 把其他 bot 的人设当成"用户偏好"提取了
- 修复：在 cron 和 eager review 两个入口跳过 admin bot 的 `reviewMemory()`
- 已清理 D1 中 Admin bot 的污染数据

## Changes

- `src/index.ts`: cron memory review 循环中跳过 `botType === "admin"` 的 bot
- `src/agent/multibot.ts`: eager review 路径增加 `botType !== "admin"` 条件
- `specs/agent/uc-05-memory-review.md`: 文档记录 admin bot 例外

## Test plan

- [x] 全部 1513 个测试通过
- [x] 已在 D1 中验证 Admin bot 的 bot_memory 已清理
- [ ] 部署后观察下次 cron（每 3 天）不再为 Admin bot 生成 MEMORY.md

Closes codance-ai/multibot-private#792

🤖 Generated with [Claude Code](https://claude.com/claude-code)