### PR TITLE
fix: add multipart abort cleanup to R2 lifecycle rules

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -188,12 +188,14 @@ else
 fi
 
 # Set lifecycle rules for R2 buckets
-npx wrangler r2 bucket lifecycle add multibot-logs expire-90d --expire-days 90 --force 2>/dev/null && \
-  ok "R2 lifecycle rule set for logs (90-day expiry)." || \
+# Note: We intentionally do NOT add InfrequentAccess transitions — for small-data
+# buckets the Class A operation costs from migration exceed the storage savings.
+npx wrangler r2 bucket lifecycle add multibot-logs expire-90d --expire-days 90 --abort-multipart-days 7 --force 2>/dev/null && \
+  ok "R2 lifecycle rule set for logs (90-day expiry + 7-day multipart abort)." || \
   warn "Could not set lifecycle rule for logs (may already exist)."
 
-npx wrangler r2 bucket lifecycle add multibot-assets expire-90d --expire-days 90 --force 2>/dev/null && \
-  ok "R2 lifecycle rule set for assets (90-day expiry)." || \
+npx wrangler r2 bucket lifecycle add multibot-assets expire-90d --expire-days 90 --abort-multipart-days 7 --force 2>/dev/null && \
+  ok "R2 lifecycle rule set for assets (90-day expiry + 7-day multipart abort)." || \
   warn "Could not set lifecycle rule for assets (may already exist)."
 
 # Derive Worker URL for BASE_URL


### PR DESCRIPTION
## Summary

- Add `--abort-multipart-days 7` to both R2 bucket lifecycle rules in `setup.sh` to clean up orphaned incomplete multipart uploads
- Add comment explaining why InfrequentAccess transitions are intentionally not configured (Class A operation costs exceed storage savings for small-data buckets)

Closes #33

## Test plan

- [x] All 1535 tests pass (no runtime code changes — setup script only)
- [ ] Verify on a fresh environment that `setup.sh` creates lifecycle rules with both expiry and multipart abort

🤖 Generated with [Claude Code](https://claude.com/claude-code)