### PR TITLE
fix: retry once on provider content-filter

### DIFF
--- a/src/agent/loop.test.ts
+++ b/src/agent/loop.test.ts
@@ -1160,13 +1160,13 @@ describe("runAgentLoop", () => {
         finishReason: "content-filter",
       }) as any)
       .mockResolvedValueOnce(mockResult({
-        text: "抱歉，刚才那条被拦截了，换个说法再试试。",
+        text: "Sorry, that reply was blocked. Could you rephrase?",
         finishReason: "end-turn",
       }) as any);
 
     const result = await runAgentLoop(baseParams);
     expect(mockGenerateText).toHaveBeenCalledTimes(2);
-    expect(result.reply).toBe("抱歉，刚才那条被拦截了，换个说法再试试。");
+    expect(result.reply).toBe("Sorry, that reply was blocked. Could you rephrase?");
     expect(result.iterations).toBe(2);
     const retryCall = mockGenerateText.mock.calls[1][0] as { messages: ModelMessage[] };
     const lastMsg = retryCall.messages[retryCall.messages.length - 1];

--- a/src/agent/loop.test.ts
+++ b/src/agent/loop.test.ts
@@ -1158,20 +1158,29 @@ describe("runAgentLoop", () => {
       .mockResolvedValueOnce(mockResult({
         text: "",
         finishReason: "content-filter",
+        messages: [{ role: "assistant", content: "" } as ModelMessage],
       }) as any)
       .mockResolvedValueOnce(mockResult({
         text: "Sorry, that reply was blocked. Could you rephrase?",
         finishReason: "end-turn",
+        messages: [{ role: "assistant", content: "Sorry, that reply was blocked. Could you rephrase?" } as ModelMessage],
       }) as any);
 
     const result = await runAgentLoop(baseParams);
     expect(mockGenerateText).toHaveBeenCalledTimes(2);
     expect(result.reply).toBe("Sorry, that reply was blocked. Could you rephrase?");
     expect(result.iterations).toBe(2);
+    // Retry call must include the synthetic system-notice user message.
+    // (Vitest records arg references, so we scan rather than peek at length-1.)
     const retryCall = mockGenerateText.mock.calls[1][0] as { messages: ModelMessage[] };
-    const lastMsg = retryCall.messages[retryCall.messages.length - 1];
-    expect(lastMsg.role).toBe("user");
-    expect(String(lastMsg.content)).toContain("content filter");
+    const hasNotice = retryCall.messages.some(
+      m => m.role === "user" && typeof m.content === "string" && m.content.includes("content filter")
+    );
+    expect(hasNotice).toBe(true);
+    // Filtered empty-assistant turn must not leak into persisted history
+    const assistants = result.newMessages.filter(m => m.role === "assistant");
+    expect(assistants).toHaveLength(1);
+    expect(assistants[0].content).toBe("Sorry, that reply was blocked. Could you rephrase?");
   });
 
   it("does not retry more than once if content-filter repeats", async () => {

--- a/src/agent/loop.test.ts
+++ b/src/agent/loop.test.ts
@@ -1152,4 +1152,41 @@ describe("runAgentLoop", () => {
     expect(result.skillCalls).toEqual([]);
     expect(result.reply).toBe("Hello!");
   });
+
+  it("retries with a system notice when provider content-filter produces an empty reply", async () => {
+    mockGenerateText
+      .mockResolvedValueOnce(mockResult({
+        text: "",
+        finishReason: "content-filter",
+      }) as any)
+      .mockResolvedValueOnce(mockResult({
+        text: "抱歉，刚才那条被拦截了，换个说法再试试。",
+        finishReason: "end-turn",
+      }) as any);
+
+    const result = await runAgentLoop(baseParams);
+    expect(mockGenerateText).toHaveBeenCalledTimes(2);
+    expect(result.reply).toBe("抱歉，刚才那条被拦截了，换个说法再试试。");
+    expect(result.iterations).toBe(2);
+    const retryCall = mockGenerateText.mock.calls[1][0] as { messages: ModelMessage[] };
+    const lastMsg = retryCall.messages[retryCall.messages.length - 1];
+    expect(lastMsg.role).toBe("user");
+    expect(String(lastMsg.content)).toContain("content filter");
+  });
+
+  it("does not retry more than once if content-filter repeats", async () => {
+    mockGenerateText
+      .mockResolvedValueOnce(mockResult({
+        text: "",
+        finishReason: "content-filter",
+      }) as any)
+      .mockResolvedValueOnce(mockResult({
+        text: "",
+        finishReason: "content-filter",
+      }) as any);
+
+    const result = await runAgentLoop(baseParams);
+    expect(mockGenerateText).toHaveBeenCalledTimes(2);
+    expect(result.reply).toBe("");
+  });
 });

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -632,6 +632,11 @@ export async function runAgentLoop(params: {
       log?.warn("Provider content-filter hit, retrying with system notice", {
         iteration: iterations,
       });
+      // Roll back the empty filtered response from persistence and LLM context
+      // so D1 does not accumulate null-content assistant rows and the retry
+      // sees a clean turn ending at the user's original message.
+      allNewMessages.length -= newMessages.length;
+      messages.length -= result.response.messages.length;
       messages.push({
         role: "user",
         content:

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -451,6 +451,8 @@ export async function runAgentLoop(params: {
   let lastModel: string | undefined;
   let currentSkill = "";
   const skillCallsMap = new Map<string, SkillToolCall[]>();
+  // Guard: only retry once after provider content-filter, to avoid loops
+  let contentFilterRetried = false;
 
   const { log } = params;
 
@@ -616,6 +618,27 @@ export async function runAgentLoop(params: {
 
     // Clear timings unconditionally — they've been consumed by Tool calls + LLM response logs
     toolTimings.clear();
+
+    // Provider content filter produced an empty reply.
+    // Mirror the image-tool-error pattern: feed the event back as a system
+    // notice and let the LLM generate a natural, language-appropriate reply
+    // on the next iteration. Capped to one retry to prevent loops.
+    if (
+      result.finishReason === "content-filter" &&
+      !accumulatedText.trim() &&
+      !contentFilterRetried
+    ) {
+      contentFilterRetried = true;
+      log?.warn("Provider content-filter hit, retrying with system notice", {
+        iteration: iterations,
+      });
+      messages.push({
+        role: "user",
+        content:
+          "[System notice: Your previous reply was blocked by the model provider's content filter and was not delivered to the user. Briefly acknowledge this to the user in the same language they are using and suggest they rephrase. Do NOT attempt to reproduce the blocked content.]",
+      });
+      continue;
+    }
 
     // If no more tool calls, we have the final answer
     if (result.finishReason !== "tool-calls") {


### PR DESCRIPTION
## Summary
- `runAgentLoop` now detects `finishReason: "content-filter"` with empty accumulated text and pushes a synthetic `user` notice so the LLM can generate a user-language acknowledgement on the next iteration
- One-shot `contentFilterRetried` flag caps the retry, so the loop cannot spin
- Synthetic notice lives only in the in-memory `messages` array; it is not persisted to D1
- Unit tests cover retry success and single-retry cap; 63/63 passing

Closes #35

## Test plan
- [x] `npx vitest run src/agent/loop.test.ts` — 63/63 pass
- [ ] Deploy and verify in prod: trigger a known content-filter scenario on the `小晚` Telegram bot and confirm an acknowledgement is delivered
- [ ] Confirm `request_trace_index` shows two iterations for the filtered turn and the second one has non-zero `outputTokens`